### PR TITLE
Fix right channel stack in plot_result

### DIFF
--- a/hrir.py
+++ b/hrir.py
@@ -570,8 +570,8 @@ class HRIR:
         left_fr = left.frequency_response()
         left_fr.smoothen_fractional_octave(window_size=1 / 3, treble_f_lower=20000, treble_f_upper=23999)
         # New Plot Logic **GPT INSERT**
-        max_len = max(ir.shape[0] for ir in stacks[0])
-        right_stack = [np.pad(ir, (0, max_len - len(ir))) for ir in stacks[0]]
+        max_len = max(ir.shape[0] for ir in stacks[1])
+        right_stack = [np.pad(ir, (0, max_len - len(ir))) for ir in stacks[1]]
         right = ImpulseResponse(np.sum(np.vstack(right_stack), axis=0), self.fs)
         # Old Plot Logic
         #right = ImpulseResponse(np.sum(np.vstack(stacks[1]), axis=0), self.fs)


### PR DESCRIPTION
## Summary
- stack right channel data using `stacks[1]` when creating `right_stack`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autoeq')*

------
https://chatgpt.com/codex/tasks/task_e_683f860c0edc83298605442be8ed4bd5